### PR TITLE
isoutils: Reorder loadable modules

### DIFF
--- a/isoutils/isoutils.go
+++ b/isoutils/isoutils.go
@@ -188,9 +188,9 @@ func mkInitrdInitScript(templatePath string) error {
 
 	//Modules to insmod during init, paths relative to the kernel folder
 	modules := []string{
-		"/kernel/fs/isofs/isofs.ko",
 		"/kernel/drivers/cdrom/cdrom.ko",
 		"/kernel/drivers/scsi/sr_mod.ko",
+		"/kernel/fs/isofs/isofs.ko",
 		"/kernel/fs/overlayfs/overlay.ko",
 	}
 


### PR DESCRIPTION
With the release of the 5.8 kernel, now isofs depends
upon cdrom; now cdrom must be loaded first.

Signed-off-by: Mark D Horn <mark.d.horn@intel.com>

**Please ensure the above *guidelines for contributing* are met.**

Fixes Issue: #

Changes proposed in this pull request:
-
-
-


